### PR TITLE
typos & zwei Fragen:

### DIFF
--- a/src/sections/fachschaftsrat.tex
+++ b/src/sections/fachschaftsrat.tex
@@ -4,7 +4,7 @@
 \item Der Fachschaftsrat Informatik führt zwischen den Vollversammlungen die Geschäfte der Fachschaft. Vom Fachschaftsrat beauftragte Fachschaftsmitglieder können ebenfalls im Namen der Fachschaft oder des Fachschaftsrates tätig werden.
 \item Der Fachschaftsrat Informatik stellt die Vertretung der Studierenden des Fachbereichs im Studierendenparlament sicher.
 \item Auf Verlangen des AStA, jedoch mindestens einmal im Monat unaufgefordert, legt der Fachschaftsrat einen Rechenschaftsbericht über die vom AStA zur Verfügung gestellten Gelder ab. Näheres regelt die Finanzordnung.
-\item Der Fachschaftsrat weist dem AStA in jeder Legislaturperiode die odrnungsgemäße Wahl seiner Mitglieder nach.
+\item Der Fachschaftsrat weist dem AStA in jeder Legislaturperiode die ordnungsgemäße Wahl seiner Mitglieder nach.
 \item Ziel der Arbeit des Fachschaftsrats ist
 \begin{itemize}
 \item Hilfe für die Fachschaftsmitglieder bei auftretenden Problemen.
@@ -21,9 +21,9 @@
 \subsection{Wahl und Zusammensetzung}
 \label{sec:zusammensetzung}
 \begin{enumerate}
-\item Der Fachschaftsrat setzt sich aus 15, mindestens jedoch fünf Mitgliedern zusammen. Die Mitgliedschaft in AStA, StuPa und Fachschaftsrat schließen sich gegensietig aus. Die Wahl erfolgt in einfacher Mehrheitswahl nach Maßgabe der Wahlordnung der Studierendenschaft der Hochschule Trier.
-\item Wahlberechtigt und Wählbar ist jedes Mitglied der Fachschaft Informatik der Hochschule Trier.
-\item Eine Briefwahl ist gemessen an der Unverhätnismäßgkeit des Aufands nicht möglich.
+\item Der Fachschaftsrat setzt sich aus 15, mindestens jedoch fünf Mitgliedern zusammen. Die Mitgliedschaft in AStA, StuPa und Fachschaftsrat schließen sich gegenseitig aus. Die Wahl erfolgt in einfacher Mehrheitswahl nach Maßgabe der Wahlordnung der Studierendenschaft der Hochschule Trier.
+\item Wahlberechtigt und wählbar ist jedes Mitglied der Fachschaft Informatik der Hochschule Trier.
+\item Eine Briefwahl ist gemessen an der Unverhältnismäßgkeit des Aufwands nicht möglich.
 \item Der Wahlausschuss besteht aus mindestens vier Mitgliedern der Fachschaft Informatik.
 \item Für die Wahl des Fachschaftsrates gilt folgendes Verfahren:
 \begin{itemize}
@@ -52,9 +52,9 @@
 \item durch Beschluss der Fachschaftsvollversammlung
 \item sofern nur noch weniger als fünf Mitglieder im Fachschaftsrat sind
 \end{itemize}
-\item Findet die Neuwahl des Fachschaftsrats in der zweiten Hälfte der Legislaturperiode des aufgelösten Fachschaftsrats statt, so verlängert sich die Amtszeit des neu gewählten Fachschaftsrats automatisch bis zum übernächsten regulären Wahltermin. Bei einer Neuwahl in der ersten Hälfte der Legislaturperiode verkürzt sich die Amtszeit auf entsprechend auf den regulären Wahltermin.
+\item Findet die Neuwahl des Fachschaftsrats in der zweiten Hälfte der Legislaturperiode des aufgelösten Fachschaftsrats statt, so verlängert sich die Amtszeit des neu gewählten Fachschaftsrats automatisch bis zum übernächsten regulären Wahltermin. Bei einer Neuwahl in der ersten Hälfte der Legislaturperiode verkürzt sich die Amtszeit entsprechend auf den regulären Wahltermin.
 \item Mit Beendigung der Amtszeit ist das Mitglied verpflichtet in seinem Besitz befindliches Eigentum oder Vermögen der Fachschaft unverzüglich zurückzugeben.
-\item Vom scheidenden Mitglied ausgeübte Amäter werden mit Ende der Amstzeit abgelegt.
+\item Vom scheidenden Mitglied ausgeübte Ämter werden mit Ende der Amtszeit abgelegt.
 \end{enumerate}
 
 \subsection{Vorstand}
@@ -70,7 +70,7 @@
 \item Die Sitzungen des Fachschaftsrats sind i.d.R öffentlich und finden mindestens einmal pro Monat statt. In der vorlesungsfreien Zeit sind die Termine nach Bedarf zu wählen.
 \item Die Sitzungen werden von dem Sprecher oder der Sprecherin oder bei Abwesenheit durch ein anderes Mitglied des Vorstands geleitet.
 \item Die Sitzung wird durch den Vorstand spätestens eine Woche innerhalb der Vorlesungszeit, spätestens zwei Wochen innerhalb der vorlesungsfreien Zeit, vor Beginn der Sitzung in geeigneter Weise bekannt gegeben. Weiterhin muss auf Antrag eines Mitglieds der Fachschaft binnen vier Wochen in Absprache mit dem Antragsteller oder der Antragsstellerin eine Sitzung einberufen werden.
-\item Beschlüsse in einer ordnungsgemäß stattfindenden Sitzung werden mit der absoluten Mehrheit der anwesenden Mitglieder gefasst. Bei Stimmengeleicheit wird nach nochmaliger Debatte über den Tagesordnungspunkt erneut abgestimmt. Sollte es erneut zu keiner Einigung kommen, entscheidet die Stimme der oder des Vorsitzenden.
-\item Über die Beschlüsse wird eine Niederschrift angefertigt die in gedruckter Form im Fachschaftsraum archiviert und den Mitgliedern der Fachschaft zur Einsicht gestellt werden muss.
-\item Der Fachschaftsrat kann auch außerhalb seiner Sitzungen Beschlüsse fasse, wenn sich der Vorstand und mehr als die Hälfte seiner Mitglieder für diesen Beschluss aussprechen und die zu behandelnde Gelegenheit unaufschiebbar ist. Über den Beschluss muss Protokoll geführt werden.
+\item Beschlüsse in einer ordnungsgemäß stattfindenden Sitzung werden mit der absoluten Mehrheit der anwesenden Mitglieder gefasst. Bei Stimmengleicheit wird nach nochmaliger Debatte über den Tagesordnungspunkt erneut abgestimmt. Sollte es erneut zu keiner Einigung kommen, entscheidet die Stimme der oder des Vorsitzenden.
+\item Über die Beschlüsse wird eine Niederschrift angefertigt, die in gedruckter Form im Fachschaftsraum archiviert und den Mitgliedern der Fachschaft zur Einsicht gestellt werden muss.
+\item Der Fachschaftsrat kann auch außerhalb seiner Sitzungen Beschlüsse fassen, wenn sich der Vorstand und mehr als die Hälfte seiner Mitglieder für diesen Beschluss aussprechen und die zu behandelnde Gelegenheit unaufschiebbar ist. Über den Beschluss muss Protokoll geführt werden.
 \end{enumerate}

--- a/src/sections/schlussbestimmung.tex
+++ b/src/sections/schlussbestimmung.tex
@@ -7,11 +7,11 @@ Bei nicht existierendem Fachschaftsrat haben die studentischen Mitglieder des Fa
 \item Satzungsänderungen dürfen nur im Rahmen der Satzung der Studierendenschaft der Hochschule Trier und der geltenden Gesetze erfolgen. Nicht inhaltliche Änderungen können ohne Beschluss der Fachschaftsvollversammlung vom Fachschaftsrat durchgeführt werden.
 \item Geplante Satzungsänderungen sollen mindestens zwei Wochen vor der beschließenden Fachschaftsvollversammlung zur Einsicht zugänglich gemacht werden.
 \item Auf Nachfrage eines Fachschaftsmitglieds müssen die Änderungen im Vergleich zur alten Satzung erläutert werden.
-\item Dem StuPa und dem AStA sind je ein Exemplar der neuen Satzung zur Verfpgung zu stellen.
+\item Dem StuPa und dem AStA sind je ein Exemplar der neuen Satzung zur Verfügung zu stellen.
 \end{enumerate}
 
 \subsection{Geschäftsordnung und Wahlordnung}
 Diese Satzung beinhaltet die Geschäftsordnung der Fachschaftsvollversammlung, sowie die Wahlordnung für die Wahlen zum Fachschaftsrat.
 
 \subsection{Inkrafttreten}
-Diese Satzung tritt nach Beschlussfassung durch die Fachschaftsvollversammlung in Kraft. Gleichzeitig tritt die alte Satzung der Fachschaft Informatik der Hochschule Trier, beschlossen am 31.10.2013 außer Kraft.
+Diese Satzung tritt nach Beschlussfassung durch die Fachschaftsvollversammlung in Kraft. Gleichzeitig tritt die alte Satzung der Fachschaft Informatik der Hochschule Trier, beschlossen am 31.10.2013, außer Kraft.

--- a/src/sections/vollversammlung.tex
+++ b/src/sections/vollversammlung.tex
@@ -6,7 +6,7 @@
 \item Der Fachschaftsvollversammlung gehören alle Mitglieder der Fachschaft Informatik an.
 \item Alle Mitglieder der Fachschaft Informatik haben in der Fachschaftsvollversammlung Antrags-, Rede- und Stimmrecht.
 \item Die Fachschaftsvollversammlung ist den Mitgliedern des Fachschaftsrates gegenüber Weisungsberechtigt und nimmt deren Berichte entgegen.
-\item Die Fachschaftsvollversammlung gibt sich eine eigene Geschäftsordnung sowie eine Wahlordnung für die Wahlen zum Fachschaftsrat. Die Grundlage deieser Wahlordnung ist die Wahlordnung der Studierendenschaft.
+\item Die Fachschaftsvollversammlung gibt sich eine eigene Geschäftsordnung sowie eine Wahlordnung für die Wahlen zum Fachschaftsrat. Die Grundlage dieser Wahlordnung ist die Wahlordnung der Studierendenschaft.
 \end{enumerate}
 
 \subsection{Einberufung}
@@ -23,8 +23,8 @@
 \subsection{Beschlussfähigkeit}
 \label{sec:beschlussfaehigkeit}
 \begin{enumerate}
-\item Die Fachschaftsvollversammlung ist beschlussfähig bei Anwesenheit von mindestens zehn Prozent der Fachschaftsmitglieder.
-\item \label{auszerordentlich} Bei Anwesenheit von weniger als zehn Prozent der Fachschaftsmitglieder ist eine außerordentliche Vollversammlung innerhalb von vierzehn Tagen, früstens jedoch nach 48 Stunden mit den gleichen Tagesordnungspunkten einzuberufen. Diese Fachschaftsvollversammlung ist dann ohne Rücksicht auf die Teilnehmerzahl beschlussfähig.
+\item Die Fachschaftsvollversammlung ist bei Anwesenheit von mindestens zehn Prozent der Fachschaftsmitglieder beschlussfähig.
+\item \label{auszerordentlich} Bei Anwesenheit von weniger als zehn Prozent der Fachschaftsmitglieder ist eine außerordentliche Vollversammlung innerhalb von vierzehn Tagen, frühstens jedoch nach 48 Stunden mit den gleichen Tagesordnungspunkten einzuberufen. Diese Fachschaftsvollversammlung ist dann ohne Rücksicht auf die Teilnehmerzahl beschlussfähig.
 \end{enumerate}
 
 \subsection{Beschlussfassung}


### PR DESCRIPTION
"Gibt es keine Ersatzmitglieder und ist der Fachschaftsrat nicht voll besetzt, so können
durch einstimmigen Beschluss weitere Mitglieder aus der Fachschaft aufgenommen
werden." - Gemeint: "in die Fachschaft aufgenommen werden." ?

"Der Fachschaftsrat kann aufgelöst werden:" - Optional? Etwa beim dritten Punkt bei weniger als fünf Mitgliedern. Alternativformulierung: "Der Fachschaftsrat wird aufgelöst:"
